### PR TITLE
feat: add percentage-based custom split option

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -160,8 +160,7 @@
       "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20251213.0.tgz",
       "integrity": "sha512-PJAGdKfU7hs39C2YOFNLTdrfdqG6rbaVj5UuI306zS+TPokiskRLEgUXKqS6avN9Uu9Nyuf2a0hqoumLQCnJlQ==",
       "dev": true,
-      "license": "MIT OR Apache-2.0",
-      "peer": true
+      "license": "MIT OR Apache-2.0"
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -1498,7 +1497,6 @@
       "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/utils": "3.2.4",
         "pathe": "^2.0.3",
@@ -1514,7 +1512,6 @@
       "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/pretty-format": "3.2.4",
         "magic-string": "^0.30.17",
@@ -2042,7 +2039,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2398,7 +2394,6 @@
       "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pathe": "^2.0.3"
       }
@@ -2409,7 +2404,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -2493,7 +2487,6 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",
@@ -2585,7 +2578,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "workerd": "bin/workerd"
       },

--- a/src/frontend/app.ts
+++ b/src/frontend/app.ts
@@ -77,6 +77,9 @@ const participantCheckboxes = document.getElementById('participant-checkboxes') 
 const customSplitsToggle = document.getElementById('custom-splits-toggle') as HTMLInputElement;
 const customSplitsSection = document.getElementById('custom-splits') as HTMLDivElement;
 const customSplitInputs = document.getElementById('custom-split-inputs') as HTMLDivElement;
+const splitModeAmount = document.getElementById('split-mode-amount') as HTMLInputElement;
+const splitModePercentage = document.getElementById('split-mode-percentage') as HTMLInputElement;
+const customSplitsHelper = document.getElementById('custom-splits-helper') as HTMLParagraphElement;
 const expensesList = document.getElementById('expenses-list') as HTMLUListElement;
 const balancesList = document.getElementById('balances-list') as HTMLDivElement;
 
@@ -350,6 +353,14 @@ function renderCustomSplitInputs() {
   if (!state.trip) return;
 
   const participants = state.trip.participants;
+  const isPercentageMode = splitModePercentage.checked;
+
+  // Update helper text
+  if (isPercentageMode) {
+    customSplitsHelper.textContent = 'Enter percentage for each person (must total 100%):';
+  } else {
+    customSplitsHelper.textContent = 'Enter custom amounts for each person:';
+  }
 
   customSplitInputs.innerHTML = participants
     .map(
@@ -361,10 +372,12 @@ function renderCustomSplitInputs() {
           id="split-${p.id}"
           class="split-amount-input"
           data-participant-id="${p.id}"
-          placeholder="0.00"
-          step="0.01"
+          placeholder="${isPercentageMode ? '0' : '0.00'}"
+          step="${isPercentageMode ? '0.01' : '0.01'}"
           min="0"
+          ${isPercentageMode ? 'max="100"' : ''}
         >
+        ${isPercentageMode ? '<span class="percentage-symbol">%</span>' : ''}
       </div>
     `
     )
@@ -444,29 +457,64 @@ async function handleAddExpense(event: Event) {
 
   if (customSplitsToggle.checked) {
     // Custom splits mode
+    const isPercentageMode = splitModePercentage.checked;
     splits = [];
     const splitInputs = customSplitInputs.querySelectorAll('.split-amount-input') as NodeListOf<HTMLInputElement>;
 
-    for (const input of splitInputs) {
-      const splitAmount = parseFloat(input.value);
-      if (splitAmount > 0) {
-        splits.push({
-          participant_id: parseInt(input.dataset.participantId || '0'),
-          amount: splitAmount,
-        });
+    if (isPercentageMode) {
+      // Percentage mode - collect percentages and validate they sum to 100%
+      const percentages: { participant_id: number; percentage: number }[] = [];
+
+      for (const input of splitInputs) {
+        const percentage = parseFloat(input.value);
+        if (percentage > 0) {
+          percentages.push({
+            participant_id: parseInt(input.dataset.participantId || '0'),
+            percentage: percentage,
+          });
+        }
       }
-    }
 
-    if (splits.length === 0) {
-      alert('Please enter at least one split amount');
-      return;
-    }
+      if (percentages.length === 0) {
+        alert('Please enter at least one percentage');
+        return;
+      }
 
-    // Validate that splits sum to expense amount
-    const totalSplits = splits.reduce((sum, split) => sum + split.amount, 0);
-    if (Math.abs(totalSplits - amount) > 0.01) {
-      alert(`Split amounts ($${totalSplits.toFixed(2)}) must equal expense amount ($${amount.toFixed(2)})`);
-      return;
+      // Validate that percentages sum to 100%
+      const totalPercentage = percentages.reduce((sum, p) => sum + p.percentage, 0);
+      if (Math.abs(totalPercentage - 100) > 0.01) {
+        alert(`Percentages must total 100%. Current total: ${totalPercentage.toFixed(2)}%`);
+        return;
+      }
+
+      // Convert percentages to dollar amounts
+      splits = percentages.map((p) => ({
+        participant_id: p.participant_id,
+        amount: (amount * p.percentage) / 100,
+      }));
+    } else {
+      // Dollar amount mode
+      for (const input of splitInputs) {
+        const splitAmount = parseFloat(input.value);
+        if (splitAmount > 0) {
+          splits.push({
+            participant_id: parseInt(input.dataset.participantId || '0'),
+            amount: splitAmount,
+          });
+        }
+      }
+
+      if (splits.length === 0) {
+        alert('Please enter at least one split amount');
+        return;
+      }
+
+      // Validate that splits sum to expense amount
+      const totalSplits = splits.reduce((sum, split) => sum + split.amount, 0);
+      if (Math.abs(totalSplits - amount) > 0.01) {
+        alert(`Split amounts ($${totalSplits.toFixed(2)}) must equal expense amount ($${amount.toFixed(2)})`);
+        return;
+      }
     }
   } else {
     // Equal split mode
@@ -969,6 +1017,10 @@ customSplitsToggle.addEventListener('change', () => {
     document.getElementById('participants-selection')!.style.display = 'block';
   }
 });
+
+// Toggle between amount and percentage mode
+splitModeAmount.addEventListener('change', renderCustomSplitInputs);
+splitModePercentage.addEventListener('change', renderCustomSplitInputs);
 
 // Handle browser back/forward
 window.addEventListener('popstate', handleRoute);

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -141,7 +141,17 @@
             </div>
 
             <div id="custom-splits" class="custom-splits" style="display: none;">
-              <p class="helper-text">Enter custom amounts for each person:</p>
+              <div class="split-mode-toggle">
+                <label class="radio-label">
+                  <input type="radio" name="split-mode" value="amount" id="split-mode-amount" checked>
+                  <span>Dollar Amounts</span>
+                </label>
+                <label class="radio-label">
+                  <input type="radio" name="split-mode" value="percentage" id="split-mode-percentage">
+                  <span>Percentages</span>
+                </label>
+              </div>
+              <p class="helper-text" id="custom-splits-helper">Enter custom amounts for each person:</p>
               <div id="custom-split-inputs" class="custom-split-inputs">
                 <!-- Dynamically populated -->
               </div>

--- a/src/frontend/styles.css
+++ b/src/frontend/styles.css
@@ -465,6 +465,39 @@ select:focus {
   accent-color: var(--accent-teal);
 }
 
+.split-mode-toggle {
+  display: flex;
+  gap: var(--space-md);
+  margin-bottom: var(--space-sm);
+  padding: var(--space-sm);
+  background-color: var(--surface-dark);
+  border-radius: var(--radius-md);
+}
+
+.radio-label {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+  cursor: pointer;
+  color: var(--text-secondary);
+  font-size: 0.875rem;
+  transition: color 0.2s ease;
+}
+
+.radio-label:hover {
+  color: var(--text-primary);
+}
+
+.radio-label input[type="radio"] {
+  accent-color: var(--accent-teal);
+  cursor: pointer;
+}
+
+.radio-label input[type="radio"]:checked + span {
+  color: var(--text-primary);
+  font-weight: 500;
+}
+
 .custom-split-inputs {
   display: flex;
   flex-direction: column;
@@ -473,7 +506,7 @@ select:focus {
 
 .split-input-row {
   display: grid;
-  grid-template-columns: 1fr 120px;
+  grid-template-columns: 1fr 120px auto;
   gap: var(--space-sm);
   align-items: center;
 }
@@ -481,6 +514,13 @@ select:focus {
 .split-input-row label {
   color: var(--text-secondary);
   font-size: 0.875rem;
+}
+
+.percentage-symbol {
+  color: var(--text-secondary);
+  font-size: 0.875rem;
+  font-weight: 500;
+  min-width: 20px;
 }
 
 /* Expenses List */


### PR DESCRIPTION
Added the ability to specify split amounts as percentages in addition to dollar amounts.

Changes:
- Added radio toggle to switch between dollar amounts and percentages in custom split mode
- Updated renderCustomSplitInputs() to dynamically adjust inputs based on selected mode
- Implemented percentage validation (must sum to 100%) with proper error messaging
- Automatically convert percentages to dollar amounts when creating expenses
- Added CSS styling for the new UI elements (radio buttons, percentage symbols)
- Updated split-input-row grid to accommodate percentage symbols

Users can now enter split amounts as percentages (e.g., 60%, 40%) which makes it easier to split expenses based on agreed-upon ratios.