### PR TITLE
feat: add debt simplification like Splitwise

### DIFF
--- a/src/api/balances.ts
+++ b/src/api/balances.ts
@@ -20,4 +20,16 @@ app.get('/', async (c) => {
   }
 });
 
+// GET /api/trips/:slug/balances/simplified - Get simplified debts
+app.get('/simplified', async (c) => {
+  try {
+    const trip = c.get('trip');
+    const simplifiedDebts = await db.getSimplifiedDebts(c.env.DB, trip.id);
+    return c.json(simplifiedDebts);
+  } catch (error) {
+    console.error('Error fetching simplified debts:', error);
+    return c.json({ error: 'Failed to fetch simplified debts' }, 500);
+  }
+});
+
 export default app;

--- a/src/frontend/api.ts
+++ b/src/frontend/api.ts
@@ -4,6 +4,7 @@ import type {
   Participant,
   ExpenseWithSplits,
   Balance,
+  SimplifiedDebt,
   CreateExpenseRequest,
   UpdateExpenseRequest,
 } from '../types';
@@ -259,4 +260,8 @@ export async function deleteExpense(
 
 export async function getBalances(slug: string): Promise<Balance[]> {
   return apiFetch<Balance[]>(`/api/trips/${slug}/balances`, {}, true);
+}
+
+export async function getSimplifiedDebts(slug: string): Promise<SimplifiedDebt[]> {
+  return apiFetch<SimplifiedDebt[]>(`/api/trips/${slug}/balances/simplified`, {}, true);
 }

--- a/src/frontend/styles.css
+++ b/src/frontend/styles.css
@@ -598,6 +598,66 @@ select:focus {
   color: var(--text-muted);
 }
 
+/* Balance toggle */
+.balance-toggle {
+  margin-bottom: var(--space-lg);
+  text-align: center;
+}
+
+.toggle-btn {
+  padding: 0.625rem 1.25rem;
+  border: 2px solid var(--border);
+  border-radius: var(--radius-full);
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  font-family: var(--font-sans);
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all var(--transition-base);
+}
+
+.toggle-btn:hover {
+  border-color: var(--accent-teal);
+  color: var(--accent-teal);
+  background: var(--accent-teal-glow);
+}
+
+/* Simplified debts */
+.simplified-debts-header {
+  margin-bottom: var(--space-md);
+  text-align: center;
+  color: var(--text-secondary);
+  font-size: 0.875rem;
+}
+
+.balance-item.simplified {
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  text-align: left;
+  padding: var(--space-md);
+  gap: var(--space-sm);
+  background: linear-gradient(135deg, var(--bg-secondary) 0%, var(--bg-elevated) 100%);
+  border: 1px solid var(--border);
+}
+
+.balance-item.simplified .balance-name {
+  font-size: 1rem;
+  color: var(--text-primary);
+}
+
+.balance-item.simplified .balance-amount {
+  font-size: 1.25rem;
+  color: var(--accent-teal);
+  font-weight: 700;
+}
+
+.balance-item.simplified .balance-status {
+  font-size: 0.875rem;
+  color: var(--text-muted);
+}
+
 /* States */
 .loading-state,
 .empty-state {

--- a/src/types.ts
+++ b/src/types.ts
@@ -84,6 +84,14 @@ export interface Balance {
   net: number;
 }
 
+export interface SimplifiedDebt {
+  from_participant_id: number;
+  from_participant_name: string;
+  to_participant_id: number;
+  to_participant_name: string;
+  amount: number;
+}
+
 // Cloudflare bindings
 
 export interface Env {


### PR DESCRIPTION
Implements a Splitwise-style debt simplification feature that minimizes
the number of payments needed to settle all debts within a trip.

Key changes:
- Added SimplifiedDebt type to represent payment instructions
- Implemented greedy algorithm in getSimplifiedDebts() that matches
  debtors with creditors to minimize transaction count
- Created new API endpoint GET /api/trips/:slug/balances/simplified
- Updated frontend to display simplified payment instructions by default
- Added toggle button to switch between simplified and detailed balance views
- Styled simplified debt display with clear "X pays $Y to Z" format
- Added comprehensive e2e tests covering various debt scenarios

The algorithm separates participants into creditors (those owed money)
and debtors (those who owe), then iteratively matches the largest debtor
with the largest creditor until all debts are settled.