### PR TITLE
fix: make trip loading resilient and replace password popup with modal

### DIFF
--- a/e2e/splitdumb.spec.ts
+++ b/e2e/splitdumb.spec.ts
@@ -345,24 +345,20 @@ test.describe('SplitDumb E2E Tests', () => {
   });
 
   test.describe('Password Protection', () => {
-    test('direct URL access prompts for password', async ({ page }) => {
+    test('direct URL access shows password modal', async ({ page }) => {
       // Navigate directly to a trip URL without credentials
-      // Should prompt for password and redirect to landing on cancel
-
-      let dialogSeen = false;
-      page.on('dialog', async (dialog) => {
-        dialogSeen = true;
-        expect(dialog.type()).toBe('prompt');
-        expect(dialog.message()).toContain('password');
-        await dialog.dismiss(); // Cancel the dialog
-      });
+      // Should show password modal and redirect to landing on cancel
 
       await page.goto('/some-fake-trip');
 
-      // Should have shown the password prompt
-      expect(dialogSeen).toBe(true);
+      // Should show the password entry modal
+      await expect(page.getByRole('heading', { name: 'Enter Password' })).toBeVisible();
+      await expect(page.locator('#password-entry-input')).toBeVisible();
+      await expect(page.locator('.modal').getByRole('button', { name: 'Join Trip' })).toBeVisible();
+      await expect(page.locator('.modal').getByRole('button', { name: 'Cancel' })).toBeVisible();
 
-      // Should redirect to landing page after cancelling
+      // Cancel should redirect to landing
+      await page.locator('.modal').getByRole('button', { name: 'Cancel' }).click();
       await expect(page).toHaveURL('/');
     });
   });

--- a/src/frontend/styles.css
+++ b/src/frontend/styles.css
@@ -548,6 +548,22 @@ select:focus {
   margin-bottom: var(--space-sm);
 }
 
+.error-message {
+  color: var(--danger);
+  font-size: 0.875rem;
+  margin-top: var(--space-sm);
+}
+
+.password-entry-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.password-entry-form input {
+  width: 100%;
+}
+
 .checkbox-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));


### PR DESCRIPTION
## Summary

- Fix trips created before PR 10 (event log feature) not loading by making `getEvents()` and `getPayments()` resilient to failures
- Replace native `prompt()` password entry with an inline modal for better user experience

## Changes

### Bug Fix
- Added `.catch(() => [])` to `getEvents()` and `getPayments()` calls so trips without these tables still load
- This fixes the issue where https://splitdumb.emilycogsdill.com/clever-fox-harbor wouldn't load

### UX Improvement
- Replaced browser's native password prompt with a styled modal
- Modal shows error messages inline instead of using `alert()`
- Cancel redirects to landing page

## Test plan

- [x] Unit tests pass (8 tests)
- [x] E2E tests pass (18/19, 1 flaky unrelated to changes)
- [x] Password modal test updated for new behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)