### PR TITLE
fix: handle missing payments/events tables in database queries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3550,7 +3550,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "workerd": "bin/workerd"
       },

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -333,10 +333,16 @@ export async function deleteExpense(db: D1Database, id: number): Promise<boolean
 // ============================================================================
 
 export async function getPaymentsByTrip(db: D1Database, tripId: number): Promise<Payment[]> {
-  const result = await db.prepare(
-    'SELECT * FROM payments WHERE trip_id = ? ORDER BY created_at DESC'
-  ).bind(tripId).all<Payment>();
-  return result.results || [];
+  try {
+    const result = await db.prepare(
+      'SELECT * FROM payments WHERE trip_id = ? ORDER BY created_at DESC'
+    ).bind(tripId).all<Payment>();
+    return result.results || [];
+  } catch (error) {
+    // Table may not exist for trips created before payments feature
+    console.error('Error fetching payments (table may not exist):', error);
+    return [];
+  }
 }
 
 export async function getPaymentById(db: D1Database, id: number): Promise<Payment | null> {
@@ -547,8 +553,14 @@ export async function createEventLog(
 }
 
 export async function getEventLogsByTrip(db: D1Database, tripId: number): Promise<EventLog[]> {
-  const result = await db.prepare(
-    'SELECT * FROM event_logs WHERE trip_id = ? ORDER BY created_at DESC'
-  ).bind(tripId).all<EventLog>();
-  return result.results || [];
+  try {
+    const result = await db.prepare(
+      'SELECT * FROM event_logs WHERE trip_id = ? ORDER BY created_at DESC'
+    ).bind(tripId).all<EventLog>();
+    return result.results || [];
+  } catch (error) {
+    // Table may not exist for trips created before event log feature
+    console.error('Error fetching event logs (table may not exist):', error);
+    return [];
+  }
 }


### PR DESCRIPTION
## Summary

Add try-catch to `getPaymentsByTrip` and `getEventLogsByTrip` so trips created before these features (like `clever-fox-harbor`) still load correctly.

## Root Cause

The balances API calls `getPaymentsByTrip` which queries the `payments` table. If this table doesn't exist on production (because the schema migration wasn't run), the query fails and the entire trip fails to load.

## Fix

Wrap the queries in try-catch and return empty arrays on error. This allows:
- Old trips to load without payments/events data
- Balance calculations to work (just without payment adjustments)

## Alternative

You could also run `npm run db:init:remote` to create the missing tables on production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)