### PR TITLE
ci: auto-release on merge to main

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -2,8 +2,8 @@ name: Build Android APK
 
 on:
   push:
-    tags:
-      - 'v*'
+    branches:
+      - main
 
 permissions:
   contents: write
@@ -14,6 +14,26 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get next version
+        id: version
+        run: |
+          git fetch --tags
+          LATEST=$(git tag -l 'v*' --sort=-v:refname | head -n1)
+          if [ -z "$LATEST" ]; then
+            NEXT="v0.1.0"
+          else
+            # Extract major.minor.patch
+            VERSION=${LATEST#v}
+            IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
+            # Bump minor, reset patch
+            MINOR=$((MINOR + 1))
+            NEXT="v${MAJOR}.${MINOR}.0"
+          fi
+          echo "next=$NEXT" >> $GITHUB_OUTPUT
+          echo "Next version: $NEXT"
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -27,10 +47,10 @@ jobs:
           distribution: 'temurin'
           java-version: '21'
 
-      - name: Set version from tag
+      - name: Set version in package.json
         run: |
-          VERSION=${GITHUB_REF#refs/tags/v}
-          npm pkg set version=$VERSION
+          VERSION=${{ steps.version.outputs.next }}
+          npm pkg set version=${VERSION#v}
 
       - name: Install dependencies
         run: npm ci
@@ -52,11 +72,12 @@ jobs:
 
       - name: Rename APK with version
         run: |
-          VERSION=${GITHUB_REF#refs/tags/}
+          VERSION=${{ steps.version.outputs.next }}
           mv android/app/build/outputs/apk/release/app-release.apk android/app/build/outputs/apk/release/splitdumb-${VERSION}.apk
 
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ steps.version.outputs.next }}
           files: android/app/build/outputs/apk/release/*.apk
           generate_release_notes: true


### PR DESCRIPTION
## Summary
- Change Android build workflow from tag-triggered to main-push-triggered
- Automatically bump minor version on each merge (v0.0.1 → v0.1.0 → v0.2.0)
- Create tag and GitHub release automatically

## How it works
1. On push to main, workflow fetches all tags
2. Finds latest `v*` tag and bumps minor version
3. Builds signed APK with new version
4. Creates tag and release with APK attached

No manual tagging required - every merge to main produces a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)