### PR TITLE
fix: configure mobile app to use production server

### DIFF
--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -3,7 +3,11 @@ import type { CapacitorConfig } from '@capacitor/cli';
 const config: CapacitorConfig = {
   appId: 'com.emilycogsdill.splitdumb',
   appName: 'Splitdumb',
-  webDir: 'dist'
+  webDir: 'dist',
+  server: {
+    url: 'https://splitdumb.emilycogsdill.com',
+    cleartext: false
+  }
 };
 
 export default config;


### PR DESCRIPTION
## Problem
Mobile app loads but can't create/login to trips because API calls to relative URLs like `/api/trips` don't work - there's no local server on the device.

## Solution
Configure Capacitor to load from the production server (`https://splitdumb.emilycogsdill.com`) so all API calls route correctly.

## Test plan
- Merge and wait for auto-release
- Download new APK and verify trips work

🤖 Generated with [Claude Code](https://claude.com/claude-code)