### PR TITLE
Display app version in settings modal

### DIFF
--- a/src/frontend/app.ts
+++ b/src/frontend/app.ts
@@ -1,4 +1,6 @@
 // src/frontend/app.ts
+declare const __APP_VERSION__: string;
+
 import type { TripWithParticipants, Participant, ExpenseWithSplits, Balance, SimplifiedDebt, PaymentWithNames, EventLog } from '../types';
 import {
   createTrip,
@@ -1164,6 +1166,9 @@ function showSettingsModal() {
         <p>Permanently delete this trip and all data</p>
       </div>
       <span class="arrow">→</span>
+    </div>
+    <div class="settings-version">
+      Version ${__APP_VERSION__}
     </div>
   `
   );

--- a/src/frontend/styles.css
+++ b/src/frontend/styles.css
@@ -1118,6 +1118,13 @@ select:focus {
   color: #ef4444;
 }
 
+.settings-version {
+  text-align: center;
+  padding: var(--space-lg) 0 var(--space-sm);
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
 /* Admin View Styles */
 .admin-trips-list {
   display: flex;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,12 @@
 import { defineConfig } from 'vite';
+import { readFileSync } from 'fs';
+
+const pkg = JSON.parse(readFileSync('./package.json', 'utf-8'));
 
 export default defineConfig({
+  define: {
+    __APP_VERSION__: JSON.stringify(pkg.version)
+  },
   root: 'src/frontend',
   build: {
     outDir: '../../dist',


### PR DESCRIPTION
## Summary

- Display app version number in the settings modal
- Inject version from package.json at build time via Vite

## Changes

- `vite.config.ts`: Add `define` to inject `__APP_VERSION__` from package.json
- `app.ts`: Declare global type and display version in settings modal
- `styles.css`: Add `.settings-version` styling

## Test plan

- [x] All 19 e2e tests pass
- [x] Version "1.0.0" appears in built output

🤖 Generated with [Claude Code](https://claude.com/claude-code)