### PR TITLE
Add Android app installation instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 
 Simple expense splitter for friend trips. Create a trip, add participants, log expenses, and see who owes what.
 
+## Install the Android App
+
+1. Download the latest APK from [GitHub Releases](https://github.com/emily-flambe/splitdumb/releases/latest)
+2. On your Android device, enable "Install from unknown sources" in Settings > Security (or when prompted)
+3. Open the downloaded APK file to install
+4. Launch SplitDumb from your app drawer
+
+You can also use the web app at [splitdumb.emilycogsdill.com](https://splitdumb.emilycogsdill.com)
+
 ## Tech Stack
 
 - **Backend**: Hono on Cloudflare Workers


### PR DESCRIPTION
## Summary

Add installation instructions for the Android app at the top of the README.

## Changes

- Add "Install the Android App" section with:
  - Link to GitHub Releases for APK download
  - Steps to enable unknown sources and install
  - Link to web app as alternative

🤖 Generated with [Claude Code](https://claude.com/claude-code)