### PR TITLE
style: simplify background to clean two-tone design

### DIFF
--- a/src/frontend/styles.css
+++ b/src/frontend/styles.css
@@ -60,16 +60,6 @@ html {
 body {
   font-family: var(--font-sans);
   background: var(--bg-primary);
-  background-image:
-    radial-gradient(ellipse at 10% 0%, rgba(0, 217, 192, 0.1) 0%, transparent 50%),
-    radial-gradient(ellipse at 90% 100%, rgba(168, 85, 247, 0.08) 0%, transparent 50%),
-    repeating-linear-gradient(
-      0deg,
-      transparent,
-      transparent 2px,
-      rgba(255, 255, 255, 0.01) 2px,
-      rgba(255, 255, 255, 0.01) 4px
-    );
   color: var(--text-primary);
   min-height: 100vh;
   line-height: 1.6;


### PR DESCRIPTION
## Summary
- Removes gradient overlays from body background that caused color variation/artifacts on mobile
- Simplifies to a clean two-tone design: header (#151b3a) and content (#0a0e27)

## Test plan
- [ ] Verify background is solid color without gradients
- [ ] Check on mobile/Android emulator for clean appearance
- [ ] Confirm header and content areas have distinct colors

🤖 Generated with [Claude Code](https://claude.com/claude-code)