### PR TITLE
Add clear messaging about anonymous data storage

### DIFF
--- a/src/frontend/app.ts
+++ b/src/frontend/app.ts
@@ -229,8 +229,8 @@ async function handleCreateTrip() {
     // Show credentials after a short delay to let the trip view load
     setTimeout(() => {
       showCredentialsModal(result.slug, result.password, true);
-      // Show data info modal after credentials if user hasn't seen it
-      if (!hasSeenDataInfo()) {
+      // Show data info modal after credentials if user hasn't seen it (skip in test mode)
+      if (!isTestTrip && !hasSeenDataInfo()) {
         setTimeout(() => {
           showDataInfoModal();
         }, 300);

--- a/src/frontend/app.ts
+++ b/src/frontend/app.ts
@@ -44,6 +44,9 @@ interface AdminTrip {
   updated_at: number;
 }
 
+// Local storage keys
+const DATA_INFO_SEEN_KEY = 'splitdumb_seen_data_info';
+
 // State management
 interface AppState {
   currentView: 'landing' | 'trip' | 'admin';
@@ -226,6 +229,12 @@ async function handleCreateTrip() {
     // Show credentials after a short delay to let the trip view load
     setTimeout(() => {
       showCredentialsModal(result.slug, result.password, true);
+      // Show data info modal after credentials if user hasn't seen it
+      if (!hasSeenDataInfo()) {
+        setTimeout(() => {
+          showDataInfoModal();
+        }, 300);
+      }
     }, 500);
   } catch (error) {
     if (error instanceof ApiError) {
@@ -1074,6 +1083,97 @@ function showPasswordEntryModal(slug: string) {
   observer.observe(modalOverlay, { attributes: true, attributeFilter: ['style'] });
 }
 
+// Data info tracking
+function hasSeenDataInfo(): boolean {
+  return localStorage.getItem(DATA_INFO_SEEN_KEY) === 'true';
+}
+
+function markDataInfoSeen() {
+  localStorage.setItem(DATA_INFO_SEEN_KEY, 'true');
+}
+
+function showDataInfoModal() {
+  const credentials = getCredentials();
+  const credentialsSection = credentials
+    ? `
+      <div class="data-info-credentials">
+        <p><strong>Your current trip credentials:</strong></p>
+        <div class="credential-display">
+          <div class="label">Trip URL</div>
+          <div class="value">https://splitdumb.emilycogsdill.com/${escapeHtml(credentials.slug)}</div>
+        </div>
+        <div class="credential-display">
+          <div class="label">Password</div>
+          <div class="value">${escapeHtml(credentials.password)}</div>
+        </div>
+        <button class="btn btn-secondary" id="data-info-copy-btn">Copy Credentials</button>
+      </div>
+    `
+    : '';
+
+  showModal(
+    'How Your Data Is Stored',
+    `
+    <div class="data-info-content">
+      <div class="data-info-item">
+        <span class="data-info-icon">&#128190;</span>
+        <div>
+          <h4>Stored on our servers</h4>
+          <p>Your trip data (participants, expenses, payments) is saved on our servers so you and your friends can access it from any device.</p>
+        </div>
+      </div>
+      <div class="data-info-item">
+        <span class="data-info-icon">&#128273;</span>
+        <div>
+          <h4>Access tied to credentials</h4>
+          <p>Your access is linked to the trip URL and password. If you clear your browser data, uninstall the app, or switch devices, you'll need these credentials to log back in.</p>
+        </div>
+      </div>
+      <div class="data-info-item">
+        <span class="data-info-icon">&#128203;</span>
+        <div>
+          <h4>Save your credentials</h4>
+          <p>We recommend copying your trip URL and password somewhere safe. Share them with friends who need access to the trip.</p>
+        </div>
+      </div>
+    </div>
+    ${credentialsSection}
+    <div class="modal-actions">
+      <button class="btn btn-primary" id="data-info-ok-btn">Got It</button>
+    </div>
+  `
+  );
+
+  document.getElementById('data-info-ok-btn')?.addEventListener('click', () => {
+    markDataInfoSeen();
+    hideModal();
+  });
+
+  document.getElementById('data-info-copy-btn')?.addEventListener('click', () => {
+    if (!credentials) return;
+    const shareMessage = `Join my trip on SplitDumb!
+
+https://splitdumb.emilycogsdill.com/${credentials.slug}
+Password: ${credentials.password}`;
+
+    navigator.clipboard.writeText(shareMessage).then(() => {
+      const btn = document.getElementById('data-info-copy-btn');
+      if (btn) {
+        btn.textContent = 'Copied!';
+        setTimeout(() => {
+          btn.textContent = 'Copy Credentials';
+        }, 2000);
+      }
+    });
+  });
+
+  // Also override modal close to mark as seen
+  const closeHandler = () => {
+    markDataInfoSeen();
+  };
+  modalClose.addEventListener('click', closeHandler, { once: true });
+}
+
 function showCredentialsModal(slug: string, password: string, isNewTrip = false) {
   const title = isNewTrip ? 'Trip Created!' : 'Trip Credentials';
   const intro = isNewTrip
@@ -1181,6 +1281,12 @@ function showSettingsModal() {
       </div>
       <span class="arrow">→</span>
     </div>
+    <div class="settings-divider"></div>
+    <div class="settings-info-section">
+      <h3>About Your Data</h3>
+      <p>Your trip data is stored on our servers and linked to this device. If you clear browser data or switch devices, you'll need the trip URL and password to regain access.</p>
+      <button class="btn btn-secondary btn-small" id="settings-data-info">Learn More</button>
+    </div>
     <div class="settings-version">
       Version ${__APP_VERSION__}
     </div>
@@ -1192,6 +1298,10 @@ function showSettingsModal() {
   document.getElementById('settings-view-credentials')?.addEventListener('click', handleViewCredentialsSetting);
   document.getElementById('settings-export')?.addEventListener('click', handleExportDataSetting);
   document.getElementById('settings-delete')?.addEventListener('click', handleDeleteTripSetting);
+  document.getElementById('settings-data-info')?.addEventListener('click', () => {
+    hideModal();
+    showDataInfoModal();
+  });
 }
 
 async function handleRenameTripSetting() {

--- a/src/frontend/styles.css
+++ b/src/frontend/styles.css
@@ -1494,4 +1494,82 @@ body.offline-mode {
   font-weight: 600;
   text-transform: uppercase;
   margin-left: var(--space-sm);
+/* Settings Info Section */
+.settings-divider {
+  height: 1px;
+  background: var(--border);
+  margin: var(--space-md) 0;
 }
+
+.settings-info-section {
+  background: var(--bg-primary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: var(--space-md);
+  margin-bottom: var(--space-md);
+}
+
+.settings-info-section h3 {
+  margin: 0 0 var(--space-sm);
+  font-size: 0.875rem;
+  color: var(--text-primary);
+}
+
+.settings-info-section p {
+  margin: 0 0 var(--space-md);
+  font-size: 0.8125rem;
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+
+/* Data Info Modal */
+.data-info-content {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-lg);
+  margin-bottom: var(--space-lg);
+}
+
+.data-info-item {
+  display: flex;
+  gap: var(--space-md);
+  align-items: flex-start;
+}
+
+.data-info-icon {
+  font-size: 1.5rem;
+  flex-shrink: 0;
+  width: 2rem;
+  text-align: center;
+}
+
+.data-info-item h4 {
+  margin: 0 0 var(--space-xs);
+  font-size: 0.9375rem;
+  color: var(--text-primary);
+}
+
+.data-info-item p {
+  margin: 0;
+  font-size: 0.8125rem;
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+
+.data-info-credentials {
+  background: var(--bg-primary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: var(--space-md);
+  margin-bottom: var(--space-md);
+}
+
+.data-info-credentials p {
+  margin: 0 0 var(--space-sm);
+  font-size: 0.875rem;
+}
+
+.data-info-credentials .btn {
+  margin-top: var(--space-sm);
+  width: 100%;
+>>>>>>> 2a458f9 (feat: add clear messaging about anonymous data storage)

--- a/src/frontend/styles.css
+++ b/src/frontend/styles.css
@@ -1494,6 +1494,8 @@ body.offline-mode {
   font-weight: 600;
   text-transform: uppercase;
   margin-left: var(--space-sm);
+}
+
 /* Settings Info Section */
 .settings-divider {
   height: 1px;
@@ -1572,4 +1574,4 @@ body.offline-mode {
 .data-info-credentials .btn {
   margin-top: var(--space-sm);
   width: 100%;
->>>>>>> 2a458f9 (feat: add clear messaging about anonymous data storage)
+}


### PR DESCRIPTION
## Summary

- Adds informational modal explaining how trip data is stored and accessed
- Shows the modal automatically after first trip creation
- Adds "About Your Data" section in trip settings with "Learn More" button
- Modal includes credentials display and copy functionality

The data info modal explains three key points:
1. **Stored on our servers** - Trip data is saved on servers for multi-device access
2. **Access tied to credentials** - URL and password needed after clearing browser data or switching devices
3. **Save your credentials** - Recommendation to copy/save credentials somewhere safe

## Test plan

- [ ] Create a new trip - data info modal should appear after credentials modal
- [ ] Dismiss the modal - should not appear again on subsequent trip creations
- [ ] Open Settings - "About Your Data" section should be visible with Learn More button
- [ ] Click "Learn More" - should open the data info modal
- [ ] Test "Copy Credentials" button in the modal

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)